### PR TITLE
Allowed agent to drop off external transfer

### DIFF
--- a/functions/add-conference-participant.js
+++ b/functions/add-conference-participant.js
@@ -60,8 +60,7 @@ exports.handler = async function(context, event, callback) {
     .create({
       to,
       from,
-      earlyMedia: true,
-      endConferenceOnExit: false
+      earlyMedia: true
     });
   console.log('Participant response properties:');
   Object.keys(participantsResponse).forEach(key => {


### PR DESCRIPTION
By removing endConferenceOnExit, we have the following behavior:
- Agent can add extetrnal phone numbers/legs
- Agent can end any of the legs 
- Agent can 'Hang Up' and customer1 and customer2 will be on the call (until one of them hangs up)